### PR TITLE
Code to import from sceptre

### DIFF
--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -27,7 +27,7 @@ locals {
   default_ec2_alarms = {
     cpu_high = {
       alarm_name                = var.alarm_name_custom_high != "" ? var.alarm_name_custom_high : "${module.this.id}${module.this.delimiter}cpu${module.this.delimiter}utilization${module.this.delimiter}high"
-      comparison_operator       = "GreaterThanOrEqualToThreshold"
+      comparison_operator       = var.alarm_comparison_operator_cpu_high != "" ? var.alarm_comparison_operator_cpu_high : "GreaterThanOrEqualToThreshold"
       evaluation_periods        = var.cpu_utilization_high_evaluation_periods
       metric_name               = "CPUUtilization"
       namespace                 = "AWS/EC2"
@@ -45,7 +45,7 @@ locals {
     },
     cpu_low = {
       alarm_name                = var.alarm_name_custom_low != "" ? var.alarm_name_custom_low : "${module.this.id}${module.this.delimiter}cpu${module.this.delimiter}utilization${module.this.delimiter}low"
-      comparison_operator       = "LessThanOrEqualToThreshold"
+      comparison_operator       = var.alarm_comparison_operator_cpu_low != "" ? var.alarm_comparison_operator_cpu_low : "LessThanOrEqualToThreshold"
       evaluation_periods        = var.cpu_utilization_low_evaluation_periods
       metric_name               = "CPUUtilization"
       namespace                 = "AWS/EC2"

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -26,7 +26,7 @@ resource "aws_autoscaling_policy" "scale_down" {
 locals {
   default_ec2_alarms = {
     cpu_high = {
-      alarm_name                = "${module.this.id}${module.this.delimiter}cpu${module.this.delimiter}utilization${module.this.delimiter}high"
+      alarm_name                = var.alarm_name_custom_high != "" ? var.alarm_name_custom_high : "${module.this.id}${module.this.delimiter}cpu${module.this.delimiter}utilization${module.this.delimiter}high"
       comparison_operator       = "GreaterThanOrEqualToThreshold"
       evaluation_periods        = var.cpu_utilization_high_evaluation_periods
       metric_name               = "CPUUtilization"
@@ -44,7 +44,7 @@ locals {
       insufficient_data_actions = []
     },
     cpu_low = {
-      alarm_name                = "${module.this.id}${module.this.delimiter}cpu${module.this.delimiter}utilization${module.this.delimiter}low"
+      alarm_name                = var.alarm_name_custom_low != "" ? var.alarm_name_custom_low : "${module.this.id}${module.this.delimiter}cpu${module.this.delimiter}utilization${module.this.delimiter}low"
       comparison_operator       = "LessThanOrEqualToThreshold"
       evaluation_periods        = var.cpu_utilization_low_evaluation_periods
       metric_name               = "CPUUtilization"
@@ -69,7 +69,7 @@ locals {
 
 resource "aws_cloudwatch_metric_alarm" "all_alarms" {
   for_each                  = local.all_alarms
-  alarm_name                = format("%s%s", "${module.this.id}${module.this.delimiter}", each.value.alarm_name)
+  alarm_name                = var.use_custom_name_alerts == true ? each.value.alarm_name : format("%s%s", "${module.this.id}${module.this.delimiter}", each.value.alarm_name)
   comparison_operator       = each.value.comparison_operator
   evaluation_periods        = each.value.evaluation_periods
   metric_name               = each.value.metric_name

--- a/autoscaling.tf
+++ b/autoscaling.tf
@@ -5,7 +5,7 @@ locals {
 
 resource "aws_autoscaling_policy" "scale_up" {
   count                  = local.autoscaling_enabled ? 1 : 0
-  name                   = "${module.this.id}${module.this.delimiter}scale${module.this.delimiter}up"
+  name                   = var.name_custom_policy_scale_up != "" ? var.name_custom_policy_scale_up :"${module.this.id}${module.this.delimiter}scale${module.this.delimiter}up"
   scaling_adjustment     = var.scale_up_scaling_adjustment
   adjustment_type        = var.scale_up_adjustment_type
   policy_type            = var.scale_up_policy_type
@@ -15,7 +15,7 @@ resource "aws_autoscaling_policy" "scale_up" {
 
 resource "aws_autoscaling_policy" "scale_down" {
   count                  = local.autoscaling_enabled ? 1 : 0
-  name                   = "${module.this.id}${module.this.delimiter}scale${module.this.delimiter}down"
+  name                   = var.name_custom_policy_scale_down != "" ? var.name_custom_policy_scale_down : "${module.this.id}${module.this.delimiter}scale${module.this.delimiter}down"
   scaling_adjustment     = var.scale_down_scaling_adjustment
   adjustment_type        = var.scale_down_adjustment_type
   policy_type            = var.scale_down_policy_type

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ data "aws_subnet" "this" {
 resource "aws_launch_template" "default" {
   count = module.this.enabled ? 1 : 0
 
-  name_prefix = format("%s%s", module.this.id, module.this.delimiter)
+  name_prefix = var.name_launch_template != "" ? var.name_launch_template :format("%s%s", module.this.id, module.this.delimiter)
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
@@ -156,7 +156,7 @@ locals {
 resource "aws_autoscaling_group" "default" {
   count = module.this.enabled ? 1 : 0
 
-  name_prefix               = format("%s%s", module.this.id, module.this.delimiter)
+  name_prefix               = var.name_asg != "" ? var.name_asg : format("%s%s", module.this.id, module.this.delimiter)
   vpc_zone_identifier       = var.network_interface_id == null ? var.subnet_ids : null
   availability_zones        = var.network_interface_id != null ? local.availability_zones : null
   max_size                  = var.max_size

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ data "aws_subnet" "this" {
 resource "aws_launch_template" "default" {
   count = module.this.enabled ? 1 : 0
 
-  name  = var.name_launch_template != "" ? var.name_launch_template : "${var.application}-${replace(var.region, "-", "")}-${var.role}-lt"
+  name  = var.name_launch_template
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
@@ -156,7 +156,7 @@ locals {
 resource "aws_autoscaling_group" "default" {
   count = module.this.enabled ? 1 : 0
 
-  name                      = var.name_autoscaling != "" ? var.name_autoscaling : "${var.application}-${replace(var.region, "-", "")}-${var.role}-asg"
+  name                      = var.name_autoscaling
   vpc_zone_identifier       = var.network_interface_id == null ? var.subnet_ids : null
   availability_zones        = var.network_interface_id != null ? local.availability_zones : null
   max_size                  = var.max_size

--- a/main.tf
+++ b/main.tf
@@ -5,19 +5,9 @@ data "aws_subnet" "this" {
 
 resource "aws_launch_template" "default" {
   count = module.this.enabled ? 1 : 0
-  dynamic "name_launch_template" {
-    for_each = var.name_launch_template != null ? [var.name_launch_template] : []
-    content {
-      name = var.name_launch_template
-    }
-  }
-
-  dynamic "name_prefix" {
-    for_each = var.name == null && var.name_prefix != null ? [var.name_prefix] : []
-    content {
-      name_prefix = format("%s%s", module.this.id, module.this.delimiter)
-    }
-  }
+  
+  name        = var.name_launch_template != null ? var.name_launch_template : null
+  name_prefix = var.name_launch_template == null && var.name_prefix != null ? format("%s%s", module.this.id, module.this.delimiter) : null
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
@@ -166,20 +156,9 @@ locals {
 
 resource "aws_autoscaling_group" "default" {
   count = module.this.enabled ? 1 : 0
-    dynamic "name_asg" {
-    for_each = var.name_asg != null ? [var.name_asg] : []
-    content {
-      name = var.name_asg
-    }
-  }
 
-  dynamic "name_prefix" {
-    for_each = var.name == null && var.name_prefix != null ? [var.name_prefix] : []
-    content {
-      name_prefix = format("%s%s", module.this.id, module.this.delimiter)
-    }
-  }
-
+  name        = var.name_asg != null ? var.name_asg : null
+  name_prefix = var.name_asg == null && var.name_prefix != null ? format("%s%s", module.this.id, module.this.delimiter) : null
   vpc_zone_identifier       = var.network_interface_id == null ? var.subnet_ids : null
   availability_zones        = var.network_interface_id != null ? local.availability_zones : null
   max_size                  = var.max_size

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,7 @@ data "aws_subnet" "this" {
 resource "aws_launch_template" "default" {
   count = module.this.enabled ? 1 : 0
   
-  name        = var.name_launch_template != null ? var.name_launch_template : null
-  name_prefix = var.name_launch_template == null && var.name_prefix != null ? format("%s%s", module.this.id, module.this.delimiter) : null
+  name        = var.name_launch_template != "" ? var.name_launch_template : "${var.application}-${replace(var.region, "-", "")}-${var.role}-lt"
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
@@ -157,8 +156,7 @@ locals {
 resource "aws_autoscaling_group" "default" {
   count = module.this.enabled ? 1 : 0
 
-  name        = var.name_asg != null ? var.name_asg : null
-  name_prefix = var.name_asg == null && var.name_prefix != null ? format("%s%s", module.this.id, module.this.delimiter) : null
+  name                      = var.name_autoscaling != "" ? var.name_autoscaling : "${var.application}-${replace(var.region, "-", "")}-${var.role}-asg"
   vpc_zone_identifier       = var.network_interface_id == null ? var.subnet_ids : null
   availability_zones        = var.network_interface_id != null ? local.availability_zones : null
   max_size                  = var.max_size

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ data "aws_subnet" "this" {
 resource "aws_launch_template" "default" {
   count = module.this.enabled ? 1 : 0
 
-  name        = var.name_launch_template != "" ? var.name_launch_template : "${var.application}-${replace(var.region, "-", "")}-${var.role}-lt"
+  name  = var.name_launch_template != "" ? var.name_launch_template : "${var.application}-${replace(var.region, "-", "")}-${var.role}-lt"
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "aws_subnet" "this" {
 
 resource "aws_launch_template" "default" {
   count = module.this.enabled ? 1 : 0
-  
+
   name        = var.name_launch_template != "" ? var.name_launch_template : "${var.application}-${replace(var.region, "-", "")}-${var.role}-lt"
 
   dynamic "block_device_mappings" {

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,19 @@ data "aws_subnet" "this" {
 
 resource "aws_launch_template" "default" {
   count = module.this.enabled ? 1 : 0
+  dynamic "name_launch_template" {
+    for_each = var.name_launch_template != null ? [var.name_launch_template] : []
+    content {
+      name = var.name_launch_template
+    }
+  }
 
-  name_prefix = var.name_launch_template != "" ? var.name_launch_template :format("%s%s", module.this.id, module.this.delimiter)
+  dynamic "name_prefix" {
+    for_each = var.name == null && var.name_prefix != null ? [var.name_prefix] : []
+    content {
+      name_prefix = format("%s%s", module.this.id, module.this.delimiter)
+    }
+  }
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
@@ -155,8 +166,20 @@ locals {
 
 resource "aws_autoscaling_group" "default" {
   count = module.this.enabled ? 1 : 0
+    dynamic "name_asg" {
+    for_each = var.name_asg != null ? [var.name_asg] : []
+    content {
+      name = var.name_asg
+    }
+  }
 
-  name_prefix               = var.name_asg != "" ? var.name_asg : format("%s%s", module.this.id, module.this.delimiter)
+  dynamic "name_prefix" {
+    for_each = var.name == null && var.name_prefix != null ? [var.name_prefix] : []
+    content {
+      name_prefix = format("%s%s", module.this.id, module.this.delimiter)
+    }
+  }
+
   vpc_zone_identifier       = var.network_interface_id == null ? var.subnet_ids : null
   availability_zones        = var.network_interface_id != null ? local.availability_zones : null
   max_size                  = var.max_size

--- a/variables.tf
+++ b/variables.tf
@@ -152,7 +152,7 @@ variable "mixed_instances_policy" {
   default = null
 }
 
-variable "name_asg" {
+variable "name_autoscaling" {
   description = "value of the id name for the autoscaling group"
   default = ""
   type    = string
@@ -162,12 +162,6 @@ variable "name_launch_template" {
   description = "value of the id name for the launch template"
   default = ""
   type    = string
-}
-
-variable "name_prefix" {
-  type = string
-  default = ""
-  description = "value of the id name_prefix for the autoscaling group"
 }
 
 variable "placement" {

--- a/variables.tf
+++ b/variables.tf
@@ -549,3 +549,15 @@ variable "alarm_name_custom_low" {
   description = "The name of the CloudWatch alarm for low CPU utilization."
   default     = ""
 }
+
+variable "name_custom_policy_scale_up" {
+  type        = string
+  description = "The name of the scaling policy for scaling up."
+  default     = ""
+}
+
+variable "name_custom_policy_scale_down" {
+  type        = string
+  description = "The name of the scaling policy for scaling down."
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -152,6 +152,18 @@ variable "mixed_instances_policy" {
   default = null
 }
 
+variable "name_asg" {
+  description = "value of the id name for the autoscaling group"
+  default = ""
+  type    = string
+}
+
+variable "name_launch_template" {
+  description = "value of the id name for the launch template"
+  default = ""
+  type    = string
+}
+
 variable "placement" {
   description = "The placement specifications of the instances"
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@ variable "application" {
 }
 
 variable "region" {
+  default     = ""
   description = "AWS region of the Auto Scaling Group."
   type        = string
 }
@@ -16,6 +17,7 @@ variable "image_id" {
 }
 
 variable "role" {
+  default     = ""
   description = "Role of the instances in the Auto Scaling Group."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -561,3 +561,16 @@ variable "name_custom_policy_scale_down" {
   description = "The name of the scaling policy for scaling down."
   default     = ""
 }
+
+
+variable "alarm_comparison_operator_cpu_high" {
+  type        = string
+  description = "The comparison operator for the high CPU utilization alarm."
+  default     = ""
+}
+
+variable "alarm_comparison_operator_cpu_low" {
+  type        = string
+  description = "The comparison operator for the low CPU utilization alarm."
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,25 +1,7 @@
-variable "application" {
-  default     = ""
-  description = "Application name"
-  type        = string
-}
-
-variable "region" {
-  default     = ""
-  description = "AWS region of the Auto Scaling Group."
-  type        = string
-}
-
 variable "image_id" {
   type        = string
   description = "The EC2 image ID to launch"
   default     = ""
-}
-
-variable "role" {
-  default     = ""
-  description = "Role of the instances in the Auto Scaling Group."
-  type        = string
 }
 
 variable "instance_initiated_shutdown_behavior" {

--- a/variables.tf
+++ b/variables.tf
@@ -164,6 +164,12 @@ variable "name_launch_template" {
   type    = string
 }
 
+variable "name_prefix" {
+  type = string
+  default = ""
+  description = "value of the id name_prefix for the autoscaling group"
+}
+
 variable "placement" {
   description = "The placement specifications of the instances"
 

--- a/variables.tf
+++ b/variables.tf
@@ -152,18 +152,6 @@ variable "mixed_instances_policy" {
   default = null
 }
 
-variable "name_autoscaling" {
-  description = "value of the id name for the autoscaling group"
-  default = ""
-  type    = string
-}
-
-variable "name_launch_template" {
-  description = "value of the id name for the launch template"
-  default = ""
-  type    = string
-}
-
 variable "placement" {
   description = "The placement specifications of the instances"
 
@@ -531,46 +519,56 @@ variable "instance_reuse_policy" {
   default     = null
 }
 
-
-variable "use_custom_name_alerts" {
-  type        = bool
-  description = "Set to true to use custom names for CloudWatch alarms."
-  default     = false
-}
-
-variable "alarm_name_custom_high" {
-  type        = string
-  description = "The name of the CloudWatch alarm for high CPU utilization."
-  default     = ""
-}
-
-variable "alarm_name_custom_low" {
-  type        = string
-  description = "The name of the CloudWatch alarm for low CPU utilization."
-  default     = ""
-}
-
-variable "name_custom_policy_scale_up" {
-  type        = string
-  description = "The name of the scaling policy for scaling up."
-  default     = ""
-}
-
-variable "name_custom_policy_scale_down" {
-  type        = string
-  description = "The name of the scaling policy for scaling down."
-  default     = ""
-}
-
-
 variable "alarm_comparison_operator_cpu_high" {
-  type        = string
-  description = "The comparison operator for the high CPU utilization alarm."
   default     = ""
+  description = "The comparison operator for the high CPU utilization alarm."
+  type        = string
 }
 
 variable "alarm_comparison_operator_cpu_low" {
-  type        = string
-  description = "The comparison operator for the low CPU utilization alarm."
   default     = ""
+  description = "The comparison operator for the low CPU utilization alarm."
+  type        = string
+}
+
+variable "alarm_name_custom_high" {
+  default     = ""
+  description = "The name of the CloudWatch alarm for high CPU utilization."
+  type        = string
+}
+
+variable "alarm_name_custom_low" {
+  default     = ""
+  description = "The name of the CloudWatch alarm for low CPU utilization."
+  type        = string
+}
+
+variable "name_autoscaling" {
+  description = "value of the id name for the autoscaling group"
+  default = ""
+  type    = string
+}
+
+variable "name_custom_policy_scale_down" {
+  default     = ""
+  description = "The name of the scaling policy for scaling down."
+  type        = string
+}
+
+variable "name_custom_policy_scale_up" {
+  default     = ""
+  description = "The name of the scaling policy for scaling up."
+  type        = string
+}
+
+variable "name_launch_template" {
+  description = "value of the id name for the launch template"
+  default = ""
+  type    = string
+}
+
+variable "use_custom_name_alerts" {
+  default     = false
+  description = "Set to true to use custom names for CloudWatch alarms."
+  type        = bool
 }

--- a/variables.tf
+++ b/variables.tf
@@ -530,3 +530,22 @@ variable "instance_reuse_policy" {
   description = "If warm pool and this block are configured, instances in the Auto Scaling group can be returned to the warm pool on scale in. The default is to terminate instances in the Auto Scaling group when the group scales in."
   default     = null
 }
+
+
+variable "use_custom_name_alerts" {
+  type        = bool
+  description = "Set to true to use custom names for CloudWatch alarms."
+  default     = false
+}
+
+variable "alarm_name_custom_high" {
+  type        = string
+  description = "The name of the CloudWatch alarm for high CPU utilization."
+  default     = ""
+}
+
+variable "alarm_name_custom_low" {
+  type        = string
+  description = "The name of the CloudWatch alarm for low CPU utilization."
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,23 @@
+variable "application" {
+  default     = ""
+  description = "Application name"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region of the Auto Scaling Group."
+  type        = string
+}
+
 variable "image_id" {
   type        = string
   description = "The EC2 image ID to launch"
   default     = ""
+}
+
+variable "role" {
+  description = "Role of the instances in the Auto Scaling Group."
+  type        = string
 }
 
 variable "instance_initiated_shutdown_behavior" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,9 +34,9 @@ variable "security_group_ids" {
 }
 
 variable "launch_template_version" {
-  type        = string
-  description = "Launch template version. Can be version number, `$Latest` or `$Default`"
   default     = "$Latest"
+  description = "Launch template version. Can be version number, `$Latest` or `$Default`"
+  type        = string
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
Ticket: https://theknotww.atlassian.net/browse/DEVEX-4535
This code will only be used for the devex_only branch of the [ec2-autoscaling-group-module-tf](https://github.com/tkww/ec2-autoscaling-group-module-tf) module, so we can migrate the ASGs from Sceptre to Terraform without changes. In this way, all new resources will continue to use the cloudposse in the ec2-autoscaling-group-module-tf module. I have added the necessary new variables for migration at the end of the file, as there is no alphabetical order in the original file. If necessary, I will arrange all existing and new variables in alphabetical order.
