### PR TITLE
Chore: Add new tag for asg

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,10 @@ locals {
     for key, value in module.this.tags :
     key => value if value != "" && value != null
   }
+  combined_tags = merge(
+    local.tags,
+    var.autoscaling_group_efs_tag
+  )
 }
 
 resource "aws_autoscaling_group" "default" {
@@ -266,7 +270,7 @@ resource "aws_autoscaling_group" "default" {
   }
 
   dynamic "tag" {
-    for_each = local.tags
+    for_each = local.combined_tags
     content {
       key                 = tag.key
       value               = tag.value

--- a/variables.tf
+++ b/variables.tf
@@ -543,6 +543,12 @@ variable "alarm_name_custom_low" {
   type        = string
 }
 
+variable "autoscaling_group_efs_tag" {
+  description = "A map of tags to add to the autoscaling group for EFS"
+  type        = map(string)
+  default     = {}
+}
+
 variable "name_autoscaling" {
   description = "value of the id name for the autoscaling group"
   default = ""

--- a/variables.tf
+++ b/variables.tf
@@ -547,7 +547,6 @@ variable "autoscaling_group_efs_tag" {
   default     = {}
   description = "A map of tags to add to the autoscaling group for EFS"
   type        = map(string)
-  
 }
 
 variable "name_autoscaling" {

--- a/variables.tf
+++ b/variables.tf
@@ -544,9 +544,10 @@ variable "alarm_name_custom_low" {
 }
 
 variable "autoscaling_group_efs_tag" {
+  default     = {}
   description = "A map of tags to add to the autoscaling group for EFS"
   type        = map(string)
-  default     = {}
+  
 }
 
 variable "name_autoscaling" {


### PR DESCRIPTION
In order to import the autoscaling, I need to separate one tag from the rest of the resource because it doesn't work if there is a comma between them. We need this since Puppet requires it for the configuration of the front-end servers.
problem 
Error: updating tags for CloudWatch Metric Alarm 
This change only add the tag EFSDISK = name,efsid for autoscaling resource with all tags, for metrics alarm just add the rest of the tags without the efsdisk tag